### PR TITLE
feat(frontend): add sensor status panel and API enhancements

### DIFF
--- a/custom_components/saviia/__init__.py
+++ b/custom_components/saviia/__init__.py
@@ -197,6 +197,39 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
                         metadata={"msg": "Frontend registered at /saviia-tasks"},
                     )
                 )
+
+            # Saviia Sensor Status panel
+            if await _panel_exists(hass, "saviia-sensor-status"):
+                logclient.debug(
+                    DebugArgs(
+                        status=LogStatus.SUCCESSFUL,
+                        metadata={
+                            "msg": "SAVIIA Sensor Status Panel already exists, skipping registration"
+                        },
+                    )
+                )
+            else:
+                async_register_built_in_panel(
+                    hass,
+                    component_name="custom",
+                    sidebar_title="SAVIIA Sensors",
+                    sidebar_icon="mdi:access-point-check",
+                    frontend_url_path="saviia-sensor-status",
+                    require_admin=False,
+                    config={
+                        "_panel_custom": {
+                            "name": "saviia-sensor-status",
+                            "module_url": "/frontend/saviia/saviia-sensor-status.panel.js",
+                            "embed_iframe": False,
+                        }
+                    },
+                )
+                logclient.debug(
+                    DebugArgs(
+                        status=LogStatus.SUCCESSFUL,
+                        metadata={"msg": "Frontend registered at /saviia-sensor-status"},
+                    )
+                )
         except Exception as e:  # noqa: BLE001
             logclient.error(
                 ErrorArgs(

--- a/custom_components/saviia/frontend/endpoints/tasks.endpoints.js
+++ b/custom_components/saviia/frontend/endpoints/tasks.endpoints.js
@@ -42,6 +42,14 @@ export default class TasksAPI {
                 `services/${domain}/${service}?return_response`,
                 data
             );
+            const apiMetadata = result?.api_metadata || {};
+            logger.debug(`Service ${domain}.${service} called successfully`, { apiMetadata });
+            const apiStatus = result?.api_status || 200;
+            const apiMessage = result?.api_message || "Success";
+            if (apiStatus !== 200) {
+                logger.error(`Service ${domain}.${service} returned error status`, { apiStatus, apiMessage });
+                throw new Error(`Service error: ${apiMessage} (status ${apiStatus})`);
+            }
             return result;
         } catch (error) {
             logger.error(`Error while calling service ${service}`, error);
@@ -136,6 +144,48 @@ export default class TasksAPI {
             const result = await this._callServiceWithErrorHandling('saviia', 'create_task', payload);
             logger.info('Task created via hass service', { task }, result)
             return result;
+        }
+    }
+
+    async getFailedSensors(localBackup, days) {
+        logger.info("Fetching failed sensors", { localBackup, days });
+        const payload = { local_backup_source_path: localBackup, n_days: days }
+        if (this.environment === "development") {
+            const url = `${this.baseUrl}/saviia/detect_failures?return_response`
+            const result = await this._fetchWithErrorHandling(url, {
+                method: 'POST',
+                headers: this._hassHeaders,
+                body: JSON.stringify(payload)
+            })
+            const sensors = result.service_response.api_metadata.validation
+            logger.info('Failed sensors fetched at Discord', { count: sensors.length })
+            return sensors
+        } else {
+            const result = await this._callServiceWithErrorHandling('saviia', 'detect_failures', payload);
+            logger.info('Failed sensors fetched via hass service',
+                { count: result.service_response.api_metadata.validation.length });
+            return result;
+        }
+    }
+
+    async getConfigFlowValue(key) {
+        logger.info("Fetching config flow value", { key });
+        const payload = { key }
+        if (this.environment === "development") {
+            const url = `${this.baseUrl}/saviia/get_config_value?return_response`
+            const result = await this._fetchWithErrorHandling(url, {
+                method: 'POST',
+                headers: this._hassHeaders,
+                body: JSON.stringify(payload)
+            })
+            const value = result.service_response.value
+            logger.info('Config flow value fetched at Discord', { key, value });
+            return value
+        } else {
+            const result = await this._callServiceWithErrorHandling('saviia', 'get_config_value', payload);
+            const value = result.service_response.value
+            logger.info('Config flow value fetched via hass service', { key, value });
+            return value;
         }
     }
 }

--- a/custom_components/saviia/frontend/saviia-sensor-status.panel.js
+++ b/custom_components/saviia/frontend/saviia-sensor-status.panel.js
@@ -1,0 +1,280 @@
+import {
+    LitElement,
+    html,
+    css,
+} from "https://unpkg.com/lit-element@2.4.0/lit-element.js?module";
+
+import { Styles } from "./styles/index.js";
+import TasksAPI from "./endpoints/tasks.endpoints.js";
+import { createLogger } from "./services/logger.js";
+
+const logger = createLogger("SaviiaSensorStatus");
+
+const CACHE_KEY = "saviia.sensor_status.cache.v1";
+const CACHE_INVALIDATION_EVENT = "saviia-sensor-status:invalidate-cache";
+
+class SaviiaSensorStatusPanel extends LitElement {
+    static get properties() {
+        return {
+            hass: { type: Object },
+            rows: { type: Array },
+            isLoading: { type: Boolean },
+            error: { type: String },
+            lastUpdated: { type: String },
+        };
+    }
+
+    static styles = [
+        ...new Styles().getStyles(["general", "table"]),
+        css`
+            
+        `,
+    ];
+
+    constructor() {
+        super();
+        this.rows = [];
+        this.isLoading = true;
+        this.error = "";
+        this.lastUpdated = "";
+        this.tasksAPI = null;
+        this._initialized = false;
+        this._reloadInvalidated = false;
+        this._boundInvalidateListener = this.handleCacheInvalidationEvent.bind(this);
+    }
+
+    set hass(hass) {
+        this._hass = hass;
+
+        if (!this.tasksAPI || this.tasksAPI.hass !== hass) {
+            this.tasksAPI = new TasksAPI(hass);
+        }
+
+        if (!this._initialized && hass) {
+            this._initialized = true;
+            this.fetchSensorsStatus();
+        }
+    }
+
+    get hass() {
+        return this._hass;
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this.invalidateCacheOnReload();
+        window.addEventListener(CACHE_INVALIDATION_EVENT, this._boundInvalidateListener);
+
+        // Dev mode only: allow standalone loading without Home Assistant on localhost:8000.
+        if (!this._initialized && !this._hass && window.location.hostname === "localhost" && window.location.port === "8000") {
+            this.tasksAPI = new TasksAPI();
+            this._initialized = true;
+            this.fetchSensorsStatus();
+        }
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+        window.removeEventListener(CACHE_INVALIDATION_EVENT, this._boundInvalidateListener);
+    }
+
+    handleCacheInvalidationEvent() {
+        this.clearCache();
+        this.fetchSensorsStatus(true);
+    }
+
+    invalidateCacheOnReload() {
+        if (this._reloadInvalidated) {
+            return;
+        }
+
+        this._reloadInvalidated = true;
+
+        let navigationType = "";
+        try {
+            const entries = performance.getEntriesByType("navigation");
+            navigationType = entries[0]?.type || "";
+        } catch (error) {
+            logger.warn("Could not read navigation entries", error);
+        }
+
+        if (navigationType === "reload") {
+            this.clearCache();
+            logger.info("Cache invalidated due to page reload");
+        }
+    }
+
+    clearCache() {
+        localStorage.removeItem(CACHE_KEY);
+    }
+
+    readCache() {
+        const rawCache = localStorage.getItem(CACHE_KEY);
+        if (!rawCache) return null;
+
+        try {
+            const parsed = JSON.parse(rawCache);
+            if (!Array.isArray(parsed?.rows)) {
+                return null;
+            }
+            return parsed;
+        } catch (error) {
+            logger.warn("Invalid cache format. Clearing cache.", error);
+            this.clearCache();
+            return null;
+        }
+    }
+
+    writeCache(rows, sourcePath) {
+        const payload = {
+            rows,
+            sourcePath,
+            days: 7,
+            cachedAt: new Date().toISOString(),
+        };
+        localStorage.setItem(CACHE_KEY, JSON.stringify(payload));
+    }
+
+    extractValidationPayload(result) {
+        if (result?.service_response?.api_metadata?.validation) {
+            return result.service_response.api_metadata.validation;
+        }
+
+        if (result?.api_metadata?.validation) {
+            return result.api_metadata.validation;
+        }
+
+        if (result?.validation) {
+            return result.validation;
+        }
+
+        return result;
+    }
+
+    normalizeRows(validationBySensor) {
+        if (!validationBySensor || typeof validationBySensor !== "object") {
+            return [];
+        }
+
+        return Object.entries(validationBySensor).map(([sensorName, metadata]) => ({
+            sensorName,
+            sensorFailed: Boolean(metadata?.sensor_failed),
+            consideredParam: metadata?.considered_param || "-",
+            daysWithFailures: Number(metadata?.days_with_failures ?? 0),
+            daysOutOfBound: Number(metadata?.days_out_of_bound ?? 0),
+            daysAllZeros: Number(metadata?.days_all_zeros ?? 0),
+        }));
+    }
+
+    async fetchSensorsStatus(forceRefresh = false) {
+        this.isLoading = true;
+        this.error = "";
+
+        try {
+            if (!forceRefresh) {
+                const cached = this.readCache();
+                if (cached) {
+                    this.rows = cached.rows;
+                    this.lastUpdated = cached.cachedAt;
+                    this.isLoading = false;
+                    logger.info("Using sensor status from cache", { rows: cached.rows.length });
+                    return;
+                }
+            }
+
+            const localBackupPath = await this.tasksAPI.getConfigFlowValue("local_backup_source_path");
+            if (!localBackupPath) {
+                throw new Error("No se encontro local_backup_source_path en la configuracion.");
+            }
+
+            const failedSensorsResult = await this.tasksAPI.getFailedSensors(localBackupPath, 7);
+            const validation = this.extractValidationPayload(failedSensorsResult);
+            const rows = this.normalizeRows(validation);
+
+            this.rows = rows;
+            this.lastUpdated = new Date().toISOString();
+            this.writeCache(rows, localBackupPath);
+            logger.info("Sensor status fetched and cached", { rows: rows.length });
+        } catch (error) {
+            logger.error("Error fetching sensor status", error);
+            this.error = `Error cargando estado de sensores: ${error.message}`;
+            this.rows = [];
+        } finally {
+            this.isLoading = false;
+        }
+    }
+
+
+    formatTimestamp(isoDate) {
+        if (!isoDate) return "-";
+
+        const date = new Date(isoDate);
+        if (Number.isNaN(date.getTime())) return "-";
+        return date.toLocaleString("es-ES");
+    }
+
+    renderTable() {
+        if (!this.rows.length) {
+            return html`<div class="empty">No hay sensores para mostrar.</div>`;
+        }
+
+        return html`
+            <div class="table-container">
+                <table class="tasks-table" role="grid" aria-label="Estado de sensores">
+                    <thead>
+                        <tr>
+                            <th>Sensor</th>
+                            <th>Estado</th>
+                            <th>Dias con fallas</th>
+                            <th>Dias Fuera de Rango</th>
+                            <th>Dias Todos Ceros</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        ${this.rows.map((row) => {
+                            const statusClass = row.sensorFailed ? "failed" : "ok";
+                            return html`
+                                <tr>
+                                    <td>
+                                        <div class="sensor-name">${row.sensorName}</div>
+                                        <small>${row.consideredParam}</small>
+                                    </td>
+                                    <td>
+                                        <div class="status-cell">
+                                            <span class="status-dot ${statusClass}" aria-hidden="true"></span>
+                                            <span class="status-text ${statusClass}">
+                                                ${row.sensorFailed ? "Failed" : "Healthy"}
+                                            </span>
+                                        </div>
+                                    </td>
+                                    <td>${row.daysWithFailures}</td>
+                                    <td>${row.daysOutOfBound}</td>
+                                    <td>${row.daysAllZeros}</td>
+                                </tr>
+                            `;
+                        })}
+                    </tbody>
+                </table>
+            </div>
+        `;
+    }
+
+    render() {
+        return html`
+            <section class="header">
+                <h2>Sensor Status</h2>
+                <p>Últimos 7 días</p>
+                <p class="help-text">
+                    Panel de estado de sensores de la THIES Data Logger.
+                </p>
+                <p class="meta">Ultima actualizacion: ${this.formatTimestamp(this.lastUpdated)}</p>
+            </section>
+
+            ${this.isLoading ? html`<div class="loading-spinner">Cargando estado de sensores...</div>` : null}
+            ${this.error ? html`<div class="error">${this.error}</div>` : null}
+            ${!this.isLoading && !this.error ? this.renderTable() : null}
+        `;
+    }
+}
+
+customElements.define("saviia-sensor-status", SaviiaSensorStatusPanel);

--- a/custom_components/saviia/frontend/styles/table_style.js
+++ b/custom_components/saviia/frontend/styles/table_style.js
@@ -150,6 +150,79 @@ export const tableStyle = css`
     transform: scale(0.98);
 }
 
+.header {
+    max-width: 90%;
+    margin: 1.4rem auto 0.4rem;
+}
+
+.meta {
+    color: #64727c;
+    font-size: 0.9rem;
+    text-align: center;
+    margin-top: 0.25rem;
+}
+
+.status-cell {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+}
+
+.status-dot {
+    width: 0.7rem;
+    height: 0.7rem;
+    border-radius: 50%;
+    border: 1px solid transparent;
+    flex-shrink: 0;
+}
+
+.status-dot.failed {
+    background: #d64747;
+    border-color: #b72d2d;
+    box-shadow: 0 0 0 3px rgba(214, 71, 71, 0.16);
+}
+
+.status-dot.ok {
+    background: #25a35a;
+    border-color: #128344;
+    box-shadow: 0 0 0 3px rgba(37, 163, 90, 0.16);
+}
+
+.status-text {
+    font-weight: 600;
+}
+
+.status-text.failed {
+    color: #a12626;
+}
+
+.status-text.ok {
+    color: #0f7940;
+}
+
+.sensor-name {
+    font-weight: 600;
+}
+
+.empty {
+    max-width: 90%;
+    margin: 2rem auto;
+    padding: 1rem;
+    border-radius: 0.6rem;
+    border: 1px solid #dbe3ea;
+    background: #f8fafc;
+    text-align: center;
+    color: #4e5c67;
+}
+
+.help-text {
+    color: #4e5c67;
+    font-size: 0.9rem;
+    text-align: center;
+    margin: 0.5rem auto 1.2rem;
+    max-width: 90%;
+}
+
 @media (max-width: 768px) {
     .table-container {
         width: 95%;

--- a/custom_components/saviia/manifest.json
+++ b/custom_components/saviia/manifest.json
@@ -14,5 +14,5 @@
     "requirements": [
         "saviialib==1.18.0"
     ],
-    "version": "7.5.9"
+    "version": "7.6.0"
 }


### PR DESCRIPTION
## Changes

* Added new "SAVIIA Sensors" panel with backend registration at `/saviia-sensor-status`, including safeguards against duplicate registration.
* Implemented `saviia-sensor-status` frontend component to display sensor health over the past 7 days, with caching, error handling, and dynamic data fetching.
* Extended `TasksAPI` with methods to retrieve failed sensors and configuration values, improving service integration and logging.
* Enhanced UI styles in `table_style.js` to better visualize sensor status, including improved layout, headers, and status indicators.
* Bumped integration version to `7.6.0`.