### PR TITLE
feat(frontend): Home button for mobile devices

### DIFF
--- a/custom_components/saviia/frontend/index.html
+++ b/custom_components/saviia/frontend/index.html
@@ -9,6 +9,7 @@
     <script type="module" src="saviia-get-tasks.panel.js"></script>
     <script type="module" src="saviia-gantt.panel.js"></script>
     <script type="module" src="saviia-tasks.panel.js"></script>
+    <script type="module" src="saviia-sensor-status.panel.js"></script>
 </head>
 
 <body>

--- a/custom_components/saviia/frontend/saviia-sensor-status.panel.js
+++ b/custom_components/saviia/frontend/saviia-sensor-status.panel.js
@@ -27,7 +27,37 @@ class SaviiaSensorStatusPanel extends LitElement {
     static styles = [
         ...new Styles().getStyles(["general", "table"]),
         css`
-            
+            /* Mobile-only Home button */
+            #ha-home-btn {
+                display: none;
+                position: fixed;
+                bottom: 16px;
+                right: 16px;
+                z-index: 9999;
+                background: #03a9f4;
+                color: #fff;
+                border: none;
+                border-radius: 12px;
+                width: 56px;
+                height: 56px;
+                padding: 6px;
+                display: inline-flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                box-shadow: 0 2px 6px rgba(0,0,0,0.25);
+                cursor: pointer;
+            }
+
+            #ha-home-btn .label {
+                font-size: 11px;
+                margin-top: 2px;
+                line-height: 1;
+            }
+
+            @media (max-width: 767px) {
+                #ha-home-btn { display: inline-flex; }
+            }
         `,
     ];
 
@@ -41,6 +71,15 @@ class SaviiaSensorStatusPanel extends LitElement {
         this._initialized = false;
         this._reloadInvalidated = false;
         this._boundInvalidateListener = this.handleCacheInvalidationEvent.bind(this);
+    }
+
+
+    openHome() {
+        var origin = window.location && window.location.origin;
+        if (!origin || origin === "null") {
+            origin = window.location.protocol + "//" + window.location.hostname + (window.location.port ? ":" + window.location.port : "");
+        }
+        window.location.href = origin + "/";
     }
 
     set hass(hass) {
@@ -273,6 +312,15 @@ class SaviiaSensorStatusPanel extends LitElement {
             ${this.isLoading ? html`<div class="loading-spinner">Cargando estado de sensores...</div>` : null}
             ${this.error ? html`<div class="error">${this.error}</div>` : null}
             ${!this.isLoading && !this.error ? this.renderTable() : null}
+            <!-- Mobile-only Home button -->
+            <button id="ha-home-btn" @click="${this.openHome}" aria-label="Open Home">
+                <span class="icon" aria-hidden="true">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M3 10.5L12 4l9 6.5V20a1 1 0 0 1-1 1h-5v-6H9v6H4a1 1 0 0 1-1-1V10.5z" fill="currentColor"/>
+                    </svg>
+                </span>
+                <span class="label">Home</span>
+            </button>
         `;
     }
 }

--- a/custom_components/saviia/frontend/saviia-tasks.panel.js
+++ b/custom_components/saviia/frontend/saviia-tasks.panel.js
@@ -89,12 +89,52 @@ class SaviiaTasksPanel extends LitElement {
 				padding: 0.5rem 0.6rem;
 			}
 		}
+
+		/* Mobile-only Home button */
+		#ha-home-btn {
+			display: none;
+			position: fixed;
+			bottom: 16px;
+			right: 16px;
+			z-index: 9999;
+			background: #03a9f4;
+			color: #fff;
+			border: none;
+			border-radius: 12px;
+			width: 56px;
+			height: 56px;
+			padding: 6px;
+			display: inline-flex;
+			flex-direction: column;
+			align-items: center;
+			justify-content: center;
+			box-shadow: 0 2px 6px rgba(0,0,0,0.25);
+			cursor: pointer;
+		}
+
+		#ha-home-btn .label {
+			font-size: 11px;
+			margin-top: 2px;
+			line-height: 1;
+		}
+
+		@media (max-width: 767px) {
+			#ha-home-btn { display: inline-flex; }
+		}
 	`;
 
 	constructor() {
 		super();
 		this.activeView = "checklist";
 		this.hass = null;
+	}
+
+	openHome() {
+		var origin = window.location && window.location.origin;
+		if (!origin || origin === "null") {
+			origin = window.location.protocol + "//" + window.location.hostname + (window.location.port ? ":" + window.location.port : "");
+		}
+		window.location.href = origin + "/";
 	}
 
 	set hass(hass) {
@@ -180,6 +220,16 @@ class SaviiaTasksPanel extends LitElement {
 					<saviia-create-task></saviia-create-task>
 				</section>
 			</div>
+
+				<!-- Mobile-only Home button -->
+				<button id="ha-home-btn" @click="${this.openHome}" aria-label="Open Home">
+					<span class="icon" aria-hidden="true">
+						<svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+							<path d="M3 10.5L12 4l9 6.5V20a1 1 0 0 1-1 1h-5v-6H9v6H4a1 1 0 0 1-1-1V10.5z" fill="currentColor"/>
+						</svg>
+					</span>
+					<span class="label">Home</span>
+				</button>
 		`;
 	}
 }


### PR DESCRIPTION
This pull request improves the mobile user experience for both the sensor status and tasks panels by adding a floating "Home" button that quickly navigates users back to the main page. The button is styled to only appear on mobile devices and includes an icon and label for clarity.

**Mobile UX Enhancements:**

* Added a floating "Home" button to both `saviia-sensor-status.panel.js` and `saviia-tasks.panel.js`, which appears only on mobile devices (screen width ≤ 767px) and navigates users to the home page when clicked. [[1]](diffhunk://#diff-519c449ad18f3ef789afee02393891442157057049e0bdac4a2605b03ad76e7cR315-R323) [[2]](diffhunk://#diff-47a9aa4770239422e3752a557eb616d85cb039141116f6c9acbdfe168cb3325dR223-R232)
* Implemented mobile-specific CSS styling for the "Home" button in both panels to ensure consistent appearance and positioning. [[1]](diffhunk://#diff-519c449ad18f3ef789afee02393891442157057049e0bdac4a2605b03ad76e7cL30-R60) [[2]](diffhunk://#diff-47a9aa4770239422e3752a557eb616d85cb039141116f6c9acbdfe168cb3325dR92-R123)
* Added the `openHome` method in both panels to handle navigation logic for the button. [[1]](diffhunk://#diff-519c449ad18f3ef789afee02393891442157057049e0bdac4a2605b03ad76e7cR76-R84) [[2]](diffhunk://#diff-47a9aa4770239422e3752a557eb616d85cb039141116f6c9acbdfe168cb3325dR132-R139)

**Integration:**

* Registered the new `saviia-sensor-status.panel.js` script in `index.html` to ensure the sensor status panel (with the new button) loads properly.