### PR TITLE
fix(service): add parameters configuration in netcamera service

### DIFF
--- a/custom_components/saviia/config_flow.py
+++ b/custom_components/saviia/config_flow.py
@@ -51,8 +51,6 @@ class SaviiaConfigFlow(config_entries.ConfigFlow, domain=GeneralParams.DOMAIN):
                 vol.Required(
                     "sharepoint_site_name",
                 ): str,  # THIES Data Logger Parameters
-                vol.Required("thies_ftp_server_avg_path"): str,
-                vol.Required("thies_ftp_server_ext_path"): str,
                 vol.Required("sharepoint_avg_backup_folder_name"): str,
                 vol.Required(
                     "sharepoint_ext_backup_folder_name"

--- a/custom_components/saviia/const.py
+++ b/custom_components/saviia/const.py
@@ -33,8 +33,6 @@ class ServicesParams:
         {
             "sharepoint_tenant_name",
             "sharepoint_site_name",
-            "thies_ftp_server_avg_path",
-            "thies_ftp_server_ext_path",
             "sharepoint_avg_backup_folder_name",
             "sharepoint_ext_backup_folder_name",
             "local_backup_source_path",
@@ -173,8 +171,8 @@ class ConfigDefaultsParams:
         "Shared%20Documents/General/Test_Raspberry/THIES/EXT"
     )
 
-    DEFAULT_FTP_PATH_AVG = "ftp/thies/BINFILES/ARCH_AV1"
-    DEFAULT_FTP_PATH_EXT = "ftp/thies/BINFILES/ARCH_EX1"
+    DEFAULT_FTP_PATH_AVG = "/ARCH_AV1"
+    DEFAULT_FTP_PATH_EXT = "/ARCH_EX1"
 
     # - Local Backup
     DEFAULT_SHAREPOINT_BASE_URL = "/sites/uc365_CentrosyEstacionesRegionalesUC/Shared%20Documents/General/Test_Raspberry"

--- a/custom_components/saviia/coordinator.py
+++ b/custom_components/saviia/coordinator.py
@@ -47,8 +47,6 @@ class NetcameraRatesCoordinator(SaviiaBaseCoordinator):
     def __init__(self, hass, config_entry, api):
         super().__init__(hass, config_entry, api)
         self.name = "netcamera_rates_coordinator"
-        self.latitude = config_entry.data["latitude"]
-        self.longitude = config_entry.data["longitude"]
         self.update_interval = timedelta(minutes=10)
         self.camera_service = api.get("netcamera")
         self.logclient = LogClient(
@@ -69,10 +67,7 @@ class NetcameraRatesCoordinator(SaviiaBaseCoordinator):
             )
         )
         try:
-            netcamera_rates = await self.camera_service.get_camera_rates(
-                latitude=self.latitude,
-                longitude=self.longitude,
-            )
+            netcamera_rates = await self.camera_service.get_camera_rates()
             self.data = netcamera_rates
             self.last_update = datetime_to_str(today())
             self.logclient.debug(

--- a/custom_components/saviia/services/common.py
+++ b/custom_components/saviia/services/common.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.exceptions import HomeAssistantError
 from saviialib import SaviiaAPI
 
-from custom_components.saviia.const import GeneralParams
+from custom_components.saviia.const import ConfigDefaultsParams, GeneralParams
 from custom_components.saviia.libs.log_client import (
     ErrorArgs,
     LogClient,
@@ -123,8 +123,8 @@ def _resolve_thies_call_data(
         "ftp_server_folders_path": call.data.get(
             "ftp_server_folders_path",
             [
-                config_data["thies_ftp_server_avg_path"],
-                config_data["thies_ftp_server_ext_path"],
+                ConfigDefaultsParams.DEFAULT_FTP_PATH_AVG,
+                ConfigDefaultsParams.DEFAULT_FTP_PATH_EXT,
             ],
         ),
         "local_backup_source_path": call.data.get(


### PR DESCRIPTION
This pull request makes several updates to the configuration and service handling for the Saviia integration, focusing on removing unused FTP path parameters, updating default FTP paths, and simplifying how camera rates are fetched. The changes streamline configuration, reduce unnecessary parameters, and ensure default values are set more consistently.

**Configuration and Parameter Cleanup:**

* Removed `thies_ftp_server_avg_path` and `thies_ftp_server_ext_path` from required configuration parameters and the `ServicesParams` set, as these are no longer needed. [[1]](diffhunk://#diff-fdfd80a13e716633c3f3f9c302e6c8edeb5ef379dc9b5177d3912cf42a25649dL54-L55) [[2]](diffhunk://#diff-d28a116636fbecf9d168f6fbcec8984883908284f4abe6b16fdd3ca3490beadbL36-L37)
* Updated the default FTP paths in `ConfigDefaultsParams` to use simplified values (`/ARCH_AV1` and `/ARCH_EX1` instead of the previous longer paths).

**Camera Rates Coordinator Simplification:**

* Removed the use of `latitude` and `longitude` from the `NetcameraRatesCoordinator` class, and updated the call to `get_camera_rates()` to no longer require these parameters. [[1]](diffhunk://#diff-3e8ba4c314b5738d0060ad6b1c8620f445a45d979f4de0a2d2a874a0e17413c6L50-L51) [[2]](diffhunk://#diff-3e8ba4c314b5738d0060ad6b1c8620f445a45d979f4de0a2d2a874a0e17413c6L72-R70)

**Service Call Data Handling:**

* Updated `_resolve_thies_call_data` to fetch FTP path defaults from `ConfigDefaultsParams` instead of configuration data, ensuring consistent fallback values.
* Added import of `ConfigDefaultsParams` to `services/common.py` to support the above change.