### PR TITLE
Fix: update netcamera service and add detect failures for thies data logger

### DIFF
--- a/custom_components/saviia/const.py
+++ b/custom_components/saviia/const.py
@@ -79,8 +79,8 @@ class ServicesParams:
     SERVICE_GET_NETCAMERA_RATES = "get_netcamera_rates"
     SERVICE_GET_NETCAMERA_RATES_SCHEMA = vol.Schema(
         {
-            vol.Required("latitude"): cv.latitude,
-            vol.Required("longitude"): cv.longitude,
+            vol.Optional("latitude"): cv.latitude,
+            vol.Optional("longitude"): cv.longitude,
         }
     )
     SERVICE_UPDATE_TASK = "update_task"

--- a/custom_components/saviia/manifest.json
+++ b/custom_components/saviia/manifest.json
@@ -14,5 +14,5 @@
     "requirements": [
         "saviialib==1.20.0"
     ],
-    "version": "7.6.9"
+    "version": "7.6.9.1"
 }

--- a/custom_components/saviia/services/__init__.py
+++ b/custom_components/saviia/services/__init__.py
@@ -53,6 +53,11 @@ class SaviiaServiceRegistry:
             ServicesParams.SERVICE_POST_THIES_DATA_SCHEMA,
         )
         self._register(
+            ServicesParams.SERVICE_DETECT_FAILURES,
+            self._thies_service.async_detect_failures,
+            ServicesParams.SERVICE_DETECT_FAILURES_SCHEMA,
+        )
+        self._register(
             ServicesParams.SERVICE_EXPORT_FILES,
             self._backup_service.async_export_files,
             ServicesParams.SERVICE_EXPORT_FILES_SCHEMA,
@@ -108,6 +113,7 @@ class SaviiaServiceRegistry:
         for service_name in (
             ServicesParams.SERVICE_GET_THIES_DATA,
             ServicesParams.SERVICE_POST_THIES_DATA,
+            ServicesParams.SERVICE_DETECT_FAILURES,
             ServicesParams.SERVICE_EXPORT_FILES,
             ServicesParams.SERVICE_GET_NETCAMERA_RATES,
             ServicesParams.SERVICE_UPDATE_TASK,

--- a/custom_components/saviia/services/netcamera_service.py
+++ b/custom_components/saviia/services/netcamera_service.py
@@ -36,12 +36,9 @@ class NetcameraService:
         api: SaviiaAPI = _check_api_in_entry(call.hass)
         camera_services = api.get("netcamera")
         try:
-            latitude = call.data.get("latitude")
-            longitude = call.data.get("longitude")
-            result = await camera_services.get_camera_rates(
-                latitude=latitude,
-                longitude=longitude,
-            )
+            # The underlying API instance uses its configured latitude/longitude.
+            # Ignore any latitude/longitude passed via the service call.
+            result = await camera_services.get_camera_rates()
             if result.get("status") != HTTPStatus.OK.value:
                 logclient.error(
                     ErrorArgs(

--- a/custom_components/saviia/services/thies_service.py
+++ b/custom_components/saviia/services/thies_service.py
@@ -92,3 +92,35 @@ class ThiesService:
             results.append({"entry_id": config_entry.entry_id, **result})
 
         return _format_multi_entry_response(results)
+
+    async def async_detect_failures(self, call: ServiceCall) -> ServiceResponse:
+        """Detect failures in THIES backups based on local backup and DB params."""
+        logclient.method_name = "async_detect_failures"
+        logclient.debug(DebugArgs(status=LogStatus.STARTED))
+        _ensure_domain_setup(call.hass)
+
+        results: list[dict] = []
+        for config_entry, entry_data in _iter_config_entry_contexts(call.hass):
+            api: SaviiaAPI = entry_data["api"]
+            thies_service = api.get("thies")
+
+            local_backup_source_path = call.data["local_backup_source_path"]
+            n_days = call.data["n_days"]
+            db_driver = call.data.get("db_driver")
+            db_host = call.data.get("db_host")
+            db_name = call.data.get("db_name")
+            user = call.data.get("user")
+            pwd = call.data.get("pwd")
+
+            result = await thies_service.detect_failures(
+                local_backup_source_path=local_backup_source_path,
+                n_days=n_days,
+                db_driver=db_driver,
+                db_host=db_host,
+                db_name=db_name,
+                user=user,
+                pwd=pwd,
+            )
+            results.append({"entry_id": config_entry.entry_id, **result})
+
+        return _format_multi_entry_response(results)


### PR DESCRIPTION
This pull request introduces a new service for detecting failures in THIES backups, updates the handling of netcamera rates service parameters, and makes several related improvements and maintenance changes.

### New THIES backup failure detection service

* Added the `async_detect_failures` method to `thies_service.py`, which detects failures in THIES backups based on local backup and database parameters. This service is registered and unregistered in the service setup/unload routines. [[1]](diffhunk://#diff-875fd8197b5c343cd6093352ab0617de2e9a2309af7c60317a7ad1110e99d1ceR95-R126) [[2]](diffhunk://#diff-2d68fe033ecb386e1b905d089aa7eee6380adcf1f80837cc1ae52d5b1cfa31b3R55-R59) [[3]](diffhunk://#diff-2d68fe033ecb386e1b905d089aa7eee6380adcf1f80837cc1ae52d5b1cfa31b3R116)

### Netcamera service improvements

* Changed the `get_netcamera_rates` service schema to make `latitude` and `longitude` optional rather than required in `const.py`.
* Updated the implementation in `netcamera_service.py` to ignore any latitude/longitude passed in the service call, always using the API's configured coordinates instead.

### Maintenance

* Bumped the integration version from `7.6.9` to `7.6.9.1` in `manifest.json`.